### PR TITLE
guessing best backlight folder candidate

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var input = require('diffy/input')()
 var fs = require('fs')
 var path = require('path')
 
-var FOLDER = '/sys/class/backlight/intel_backlight'
+var FOLDER = guessBestController('/sys/class/backlight/');
 var BRIGHTNESS_FILE = path.join(FOLDER, 'brightness')
 var MAX_BRIGHTNESS_FILE = path.join(FOLDER, 'max_brightness')
 var MAX = readInt(MAX_BRIGHTNESS_FILE)
@@ -59,3 +59,14 @@ function render () {
 }
 
 function noop () {}
+
+function guessBestController(basePath) {
+  var candidates = fs.readdirSync(basePath);
+  for(var i=0; i<candidates.length; i++) {
+    var type = fs.readFileSync(path.join(basePath,candidates[i],'type'), 'ascii');
+    if (type.substr(0,3) === 'raw') {
+      return path.join(basePath, candidates[i]);
+    }
+  }
+  return candidates[0] || null;
+}


### PR DESCRIPTION
Hi!

This utility wasn't working on my Debian with _Mobility Radeon HD 5850_ because obviously I have no _/sys/class/backlight/intel_backlight_ folder.

Instead I got two folders: _/sys/class/backlight/acpi_video0_ and _/sys/class/backlight/radeon_bl0_.

With a little research [[1](https://bbs.archlinux.org/viewtopic.php?id=157737)] I have found that the one with the file **type** containing "raw", despite of what [this kernel doc](https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-backlight) is saying.

I have also checked it on a Dell XPS13 (with /intel_backlight), and it's still working.

